### PR TITLE
ODATA-2: Update nuget package to contain proper information

### DIFF
--- a/evergreen/evergreen.yml
+++ b/evergreen/evergreen.yml
@@ -153,7 +153,7 @@ functions:
           MONGODB_VERSION=${VERSION} \
           STORAGE_ENGINE=${STORAGE_ENGINE} \
           ORCHESTRATION_FILE=${ORCHESTRATION_FILE} \
-            sh ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
+            bash ${DRIVERS_TOOLS}/.evergreen/run-orchestration.sh
     # run-orchestration generates expansion file with the MONGODB_URI for the cluster
     - command: expansions.update
       params:
@@ -186,7 +186,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: ./mongo-aspnetcore-odata/build/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.nupkg
+        local_file: ./mongo-aspnetcore-odata/artifacts/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.nupkg
         remote_file: ${revision}/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.nupkg
         bucket: ${aws_upload_bucket}
         permissions: public-read
@@ -195,7 +195,7 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: ./mongo-aspnetcore-odata/build/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.snupkg
+        local_file: ./mongo-aspnetcore-odata/artifacts/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.snupkg
         remote_file: ${revision}/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.snupkg
         bucket: ${aws_upload_bucket}
         permissions: public-read
@@ -206,14 +206,14 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: ./mongo-aspnetcore-odata/build/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.nupkg
+        local_file: ./mongo-aspnetcore-odata/artifacts/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.nupkg
         remote_file: ${revision}/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.nupkg
         bucket: ${aws_upload_bucket}
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: ./mongo-aspnetcore-odata/build/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.snupkg
+        local_file: ./mongo-aspnetcore-odata/artifacts/nuget/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.snupkg
         remote_file: ${revision}/MongoDB.AspNetCore.OData.${PACKAGE_VERSION}.snupkg
         bucket: ${aws_upload_bucket}
 
@@ -381,11 +381,11 @@ axes:
         variables:
           OS: "ubuntu-1804"
         run_on: ubuntu1804-test
-      - id: "macos-1100"
-        display_name: "macOS 11.00"
+      - id: "ubuntu-2004"
+        display_name: "Ubuntu 20.04"
         variables:
-          OS: "macos-1100"
-        run_on: macos-1100
+          OS: "ubuntu-2004"
+        run_on: ubuntu2004-test
 
   - id: driver
     display_name: MongoDB.Driver Version
@@ -398,10 +398,29 @@ axes:
         display_name: "2.21"
         variables:
           DRIVER_VERSION: "2.21"
+      - id: "2.22"
+        display_name: "2.22"
+        variables:
+          DRIVER_VERSION: "2.22"
+      - id: "2.23"
+        display_name: "2.23"
+        variables:
+          DRIVER_VERSION: "2.23"
+      - id: "2.24"
+        display_name: "2.24"
+        variables:
+          DRIVER_VERSION: "2.24"
 
 buildvariants:
 - matrix_name: "tests"
-  matrix_spec: { version: "*", os: ["windows-64", "ubuntu-1804"], driver: "*" }
+  matrix_spec: { version: ["4.2", "4.4", "5.0", "6.0"], os: ["windows-64", "ubuntu-1804"], driver: "*" }
+  display_name: "${driver} Driver on ${os} with ${version} Server"
+  tags: ["tests-variant"]
+  tasks:
+    - name: test-net50
+
+- matrix_name: "tests-7.0+"
+  matrix_spec: { version: ["7.0", "latest", "rapid"], os: ["windows-64", "ubuntu-2004"], driver: "*" }
   display_name: "${driver} Driver on ${os} with ${version} Server"
   tags: ["tests-variant"]
   tasks:

--- a/evergreen/run-pack.sh
+++ b/evergreen/run-pack.sh
@@ -10,4 +10,4 @@ fi
 echo Creating nuget package...
 
 dotnet clean ./MongoDB.AspNetCore.OData.sln
-dotnet pack ./MongoDB.AspNetCore.OData.sln -o ./build/nuget -c Release -p:Version="$PACKAGE_VERSION" --include-symbols -p:SymbolPackageFormat=snupkg
+dotnet pack ./MongoDB.AspNetCore.OData.sln -o ./artifacts/nuget -c Release -p:Version="$PACKAGE_VERSION" --include-symbols -p:SymbolPackageFormat=snupkg -p:ContinuousIntegrationBuild=true

--- a/evergreen/run-push.sh
+++ b/evergreen/run-push.sh
@@ -9,4 +9,4 @@ fi
 # validate "clear" version. x.y.z[-abc1]
 
 echo Pushing nuget package...
-dotnet nuget push ./build/nuget/MongoDB.AspNetCore.OData."$PACKAGE_VERSION".nupkg  -s https://api.nuget.org/v3/index.json -k "$NUGET_KEY"
+dotnet nuget push ./artifacts/nuget/MongoDB.AspNetCore.OData."$PACKAGE_VERSION".nupkg  -s https://api.nuget.org/v3/index.json -k "$NUGET_KEY"

--- a/evergreen/run-smoketests.sh
+++ b/evergreen/run-smoketests.sh
@@ -15,7 +15,7 @@ ODATA_TESTS_PROJECT="./tests/MongoDB.AspNetCore.OData.Tests/MongoDB.AspNetCore.O
 echo Retargeting API tests to use generated package instead of project dependency...
 dotnet clean "./MongoDB.AspNetCore.OData.sln"
 
-dotnet nuget add source "./build/nuget" -n local --configfile "./nuget.config"
+dotnet nuget add source "./artifacts/nuget" -n local --configfile "./nuget.config"
 dotnet nuget locals temp -c
 dotnet remove "$ODATA_SAMPLE_PROJECT" reference "$ODATA_PROJECT"
 dotnet add "$ODATA_SAMPLE_PROJECT" package "MongoDB.AspNetCore.OData" -v "$PACKAGE_VERSION"

--- a/src/MongoDB.AspNetCore.OData/MongoDB.AspNetCore.OData.csproj
+++ b/src/MongoDB.AspNetCore.OData/MongoDB.AspNetCore.OData.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -12,11 +11,23 @@
     <Product>MongoDB.AspNetCore.OData</Product>
     <PackageId>MongoDB.AspNetCore.OData</PackageId>
     <Description>Official MongoDB integration library for ASP.NET Core OData.</Description>
+    <PackageTags>mongodb;mongo;nosql;odata</PackageTags>
+    <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageLanguage>en-US</PackageLanguage>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.1.2" />
     <PackageReference Include="MongoDB.Driver" Version="2.21.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
PR contains multiple fixes:
- Add some nuget package metadata as per https://jira.mongodb.org/projects/ODATA/issues/ODATA-2
- Use bash to run mongo-orchestration script similar to https://jira.mongodb.org/browse/CSHARP-5004
- Fix package creation to make nuget validation happy similar to https://jira.mongodb.org/browse/CSHARP-3994
- Use Ubuntu 20 to run Mongo 7+ versions
- Rename build folder to artifacts to follow Driver naming convensions
- Add recent versions to  Driver's axes
- Configured PR build